### PR TITLE
CP-668 Release state_machine 1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: state_machine
-version: 0.0.0
+version: 1.0.0
 dev_dependencies:
   browser: "^0.10.0"
   dart_style: "^0.1.8"


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-668

JIRA and PR's included in this release: 


 CP-667  - Initial `state_machine` implementation  - https://github.com/Workiva/state_machine/pull/1
 CP-691  - Add changelog, state_machine  - https://github.com/Workiva/state_machine/pull/7
 CP-692  - Add Apache 2.0 license, state_machine  - https://github.com/Workiva/state_machine/pull/6
 CP-699  - Add dartfmt and analyze steps to CI build  - https://github.com/Workiva/state_machine/pull/9
 CP-707  - Setup Travis CI, state_machine  - https://github.com/Workiva/state_machine/pull/10
 CP-720  - Temporarily remove coverage dependencies, state_machine.  - https://github.com/Workiva/state_machine/pull/11

Diff Between Last Tag and Proposed Release: N/A

    