### PR TITLE
CP-970 Add helpful toString() overrides for debugging

### DIFF
--- a/example/door.dart
+++ b/example/door.dart
@@ -18,7 +18,7 @@ import 'package:state_machine/state_machine.dart';
 
 class Door {
   Door() {
-    _machine = new StateMachine();
+    _machine = new StateMachine('door');
 
     isClosed = _machine.newState('closed');
     isLocked = _machine.newState('locked');
@@ -42,4 +42,7 @@ class Door {
   StateTransition unlock;
 
   StateMachine _machine;
+
+  @override
+  String toString() => _machine.toString();
 }

--- a/example/door_example.dart
+++ b/example/door_example.dart
@@ -42,7 +42,9 @@ openDoor() {
   querySelector('#door-frame').className = 'open';
 }
 
-illegalStateTransition(Element state) {
+illegalStateTransition(Element state, e) {
+  print('');
+  print(e);
   state.className += ' illegal';
   new Timer(new Duration(milliseconds: 100), () {
     state.className = 'state';
@@ -54,16 +56,25 @@ void main() {
 
   // Wire up state changes to DOM changes
   door.isClosed.onEnter.listen((StateChange change) {
+    print('');
+    print(change);
+    print(door);
     activateState(door.isClosed);
     closeDoor();
   });
 
   door.isLocked.onEnter.listen((StateChange change) {
+    print('');
+    print(change);
+    print(door);
     activateState(door.isLocked);
     lockDoor();
   });
 
   door.isOpen.onEnter.listen((StateChange change) {
+    print('');
+    print(change);
+    print(door);
     activateState(door.isOpen);
     openDoor();
   });
@@ -75,8 +86,8 @@ void main() {
   open.onClick.listen((event) {
     try {
       door.open();
-    } on IllegalStateTransition {
-      illegalStateTransition(open);
+    } on IllegalStateTransition catch (e) {
+      illegalStateTransition(open, e);
     }
   });
   close.onClick.listen((event) {
@@ -89,8 +100,19 @@ void main() {
   lock.onClick.listen((event) {
     try {
       door.lock();
-    } on IllegalStateTransition {
-      illegalStateTransition(lock);
+    } on IllegalStateTransition catch (e) {
+      illegalStateTransition(lock, e);
     }
   });
+
+  print(door);
+  print('');
+  print(door.isOpen);
+  print(door.isClosed);
+  print(door.isLocked);
+  print('');
+  print(door.open);
+  print(door.close);
+  print(door.lock);
+  print(door.unlock);
 }

--- a/test/state_machine_test.dart
+++ b/test/state_machine_test.dart
@@ -22,12 +22,14 @@ import 'package:test/test.dart';
 
 void main() {
   group('StateMachine', () {
-    var machine;
-    var state;
+    StateMachine machine;
+    State state;
+    State otherState;
 
     setUp(() {
-      machine = new StateMachine();
+      machine = new StateMachine('machine');
       state = machine.newState('state');
+      otherState = machine.newState('other');
     });
 
     test('should be in a dummy state until the machine has been started', () {
@@ -79,6 +81,13 @@ void main() {
               .toString()
               .contains('Cannot create new state transition (transition)'),
           isTrue);
+    });
+
+    test('.toString() should provide a helpful result', () {
+      machine.start(state);
+      String s = machine.toString();
+      expect(s, contains(machine.name));
+      expect(s, contains('${state.name} (active)'));
     });
   });
 }

--- a/test/state_test.dart
+++ b/test/state_test.dart
@@ -27,7 +27,7 @@ void main() {
     StateTransition turnOn;
 
     setUp(() {
-      machine = new StateMachine();
+      machine = new StateMachine('machine');
       isOn = machine.newState('on');
       isOff = machine.newState('off');
       turnOn = machine.newStateTransition('turnOn', [isOff], isOn);
@@ -60,6 +60,28 @@ void main() {
       expect(isOff(), isTrue);
       turnOn();
       expect(isOn(), isTrue);
+    });
+
+    test('.toString() should provide a helpful result', () async {
+      machine.start(isOn);
+      await isOn.onEnter.first;
+
+      String isOnStr = isOn.toString();
+      expect(isOnStr, contains(isOn.name));
+      expect(isOnStr, contains(machine.name));
+      expect(isOnStr, contains('active: true'));
+
+      String isOffStr = isOff.toString();
+      expect(isOffStr, contains(isOff.name));
+      expect(isOffStr, contains(machine.name));
+      expect(isOffStr, contains('active: false'));
+    });
+
+    test('.toString() should explain what the __none__ state means', () {
+      State noneState = machine.current;
+      String s = noneState.toString();
+      expect(s, contains('machine has yet to start'));
+      expect(s, isNot(contains('__none__')));
     });
   });
 }


### PR DESCRIPTION
## Issue
#13 State machine logic can be complicated and logging debug information about the machine is annoying to do manually.

## Changes
**Source:**
- **BREAKING** &nbsp; Require a `name` parameter when constructing a state machine
  - We could make this backwards compat and deprecate for a future breaking release, but this repo is stable enough that I'm leaning towards making the breaking change now. Thoughts?
- Add `toString()` overrides for `StateMachine`, `State`, `StateTransition`, and `StateChange

**Tests:**
- Add tests for all of these `toString()` methods

## Areas of Regression
- n/a

## Testing
- CI passes

## Example output:
https://drive.google.com/file/d/0B0mRcThhKeMGYmhvb3F2TXNrdEk/view?usp=sharing

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf