### PR TITLE
CP-981 Updating example so that close behaves the same as open and lock

### DIFF
--- a/example/door_example.dart
+++ b/example/door_example.dart
@@ -91,10 +91,14 @@ void main() {
     }
   });
   close.onClick.listen((event) {
-    if (door.isLocked()) {
-      door.unlock();
-    } else {
-      door.close();
+    try {
+      if (door.isLocked()) {
+        door.unlock();
+      } else {
+        door.close();
+      }
+    } on IllegalStateTransition catch (e) {
+      illegalStateTransition(close, e);
     }
   });
   lock.onClick.listen((event) {


### PR DESCRIPTION
## Issue
- If you double click the close button in the example an error is thrown.  If you perform the same action on the open or lock buttons the error is caught and logged in the console.

## Changes
**Source:**
- Added a try catch block to the close event

**Tests:**
- N/A, this is just an update to the example

## Areas of Regression
- The close state

## Testing
- Make sure the example still works as expected
- Ensure that when double clicking or causing an illegal state transition around the close state that no error is thrown but rather a helpful statement is logged

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf