### PR TITLE
CP-2624 The codecov badge was no longer working

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dart State Machine
 [![Pub](https://img.shields.io/pub/v/state_machine.svg)](https://pub.dartlang.org/packages/state_machine)
 [![Build Status](https://travis-ci.org/Workiva/state_machine.svg?branch=master)](https://travis-ci.org/Workiva/state_machine)
-[![codecov.io](http://codecov.io/github/Workiva/state_machine/coverage.svg?branch=master)](http://codecov.io/github/Workiva/state_machine?branch=master)
+[![codecov.io](https://codecov.io/gh/Workiva/state_machine/branch/master/graph/badge.svg)](http://codecov.io/github/Workiva/state_machine?branch=master)
 [![documentation](https://img.shields.io/badge/Documentation-state_machine-blue.svg)](https://www.dartdocs.org/documentation/state_machine/latest/)
 
 > Easily create a finite state machine and define legal state transitions. Listen to state entrances, departures, and transitions.


### PR DESCRIPTION
## Issue
- The link codecov badge was no longer pointing to an appropriate url.

## Changes
**Source:**
- Updated url.

**Tests:**
- n/a

## Areas of Regression
- Broken codecov badge

## Testing
- verify readme at https://github.com/Workiva/state_machine/tree/badge_update displays the correct badge

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf
