### PR TITLE
CP-2945 Adding smithy.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: dart
 dart:
   - stable
 script:
+  - pub get --packages-dir
   - pub run dart_dev analyze
   - pub run dart_dev format --check
   - pub run dart_dev test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ authors:
 homepage: https://github.com/Workiva/state_machine
 dev_dependencies:
   browser: "^0.10.0"
-  coverage: "^0.7.2"
+  coverage: "^0.7.3"
   dart_dev: "^1.0.0"
   dart_style: "^0.2.0"
   dartdoc: "^0.8.0"

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,0 +1,12 @@
+project: dart
+language: dart
+
+# dart 1.19.1
+runner_image: drydock-prod.workiva.org/workiva/smithy-runner-generator:92530
+
+script:
+  - pub get
+
+artifacts:
+  build:
+    - ./pubspec.lock


### PR DESCRIPTION
## Issue
- We needed to add a smithy.yaml for release management to more easily track dependencies.

## Changes
**Source:**
- Included smithy.yaml

**Tests:**
- n/a

## Areas of Regression
- passing CI's

## Testing
- passing CI

## Code Review
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf
@sebastianmalysa-wf 