### PR TITLE
Wp 3756 : state_machine is now disposable

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,63 @@
+analyzer:
+  strong-mode: true
+
+linter:
+  rules:
+#    - always_declare_return_types
+#    - annotate_overrides
+#    - avoid_empty_else
+#    - avoid_init_to_null
+#    - avoid_return_types_on_setters
+#    - await_only_futures
+#    - camel_case_types
+    - cancel_subscriptions
+    - close_sinks
+#    - comment_references
+#    - constant_identifier_names
+#    - control_flow_in_finally
+#    - empty_catches
+#    - empty_constructor_bodies
+#    - empty_statements
+#    - hash_and_equals
+#    - invariant_boolean
+#    - iterable_contains_unrelated_type
+#    - library_names
+#    - library_prefixes
+#    - list_remove_unrelated_type
+#    - literal_only_boolean_expressions
+#    - only_throw_errors
+#    - overridden_fields
+#    - package_api_docs
+#    - package_names
+#    - package_prefixed_library_names
+#    - parameter_assignments
+#    - prefer_final_fields
+#    - prefer_final_locals
+#    - prefer_is_not_empty
+#    - public_member_api_docs
+#    - slash_for_doc_comments
+#    - sort_constructors_first
+#    - sort_unnamed_constructors_first
+#    - super_goes_last
+#    - test_types_in_equals
+#    - throw_in_finally
+#    - type_annotate_public_apis
+#    - type_init_formals
+#    - unawaited_futures
+#    - unnecessary_brace_in_string_interp
+#    - unnecessary_getters_setters
+#    - unrelated_type_equality_checks
+#    - valid_regexps
+
+# This rule forces overly verbose declaration of variables.
+  #- always_specify_type
+
+# This rule isn't currently enabled becaus there are valid uses for using 'as', such as
+# verifying that an object is a specific mixin.
+#    - avoid_as
+
+# These rules were found to be unenforceable as they would require breaking changes or
+# were too noisy.
+#    - implementation_imports
+#    - non_constant_identifier_names
+#    - one_member_abstracts

--- a/example/door.dart
+++ b/example/door.dart
@@ -17,7 +17,7 @@ library state_machine.example.door;
 import 'package:state_machine/state_machine.dart';
 import 'package:w_common/disposable.dart';
 
-class Door extends Disposable{
+class Door extends Disposable {
   Door() {
     _machine = new StateMachine('door');
     manageDisposable(_machine);

--- a/example/door.dart
+++ b/example/door.dart
@@ -15,11 +15,12 @@
 library state_machine.example.door;
 
 import 'package:state_machine/state_machine.dart';
+import 'package:w_common/disposable.dart';
 
-class Door {
+class Door extends Disposable{
   Door() {
     _machine = new StateMachine('door');
-
+    manageDisposable(_machine);
     isClosed = _machine.newState('closed');
     isLocked = _machine.newState('locked');
     isOpen = _machine.newState('open');

--- a/lib/src/state_machine.dart
+++ b/lib/src/state_machine.dart
@@ -104,7 +104,8 @@ class State extends Disposable implements Function {
 
     if (!listenTo) return;
 
-    manageStreamSubscription(_machine.onStateChange.listen((StateChange stateChange) {
+    manageStreamSubscription(
+        _machine.onStateChange.listen((StateChange stateChange) {
       if (stateChange.from == this) {
         // Left this state. Notify listeners.
         _onLeaveController.add(stateChange);
@@ -207,7 +208,7 @@ class StateChange {
 /// Once initialized, the state machine is driven by the
 /// states and the state transitions. See [State] and
 /// [StateTransition] for more information.
-class StateMachine extends Disposable{
+class StateMachine extends Disposable {
   /// Name of the state machine. Used for debugging.
   String name;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,9 @@ authors:
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/state_machine
+
+dependencies:
+  w_common: ^1.2.0
 dev_dependencies:
   browser: "^0.10.0"
   coverage: "^0.7.3"


### PR DESCRIPTION
Purpose
-------

Several stream subscriptions and stream controllers were not being correctly managed.

Solution
--------

Stream subscriptions and stream controllers are now managed.

Semantic Versioning (check one)
-------------------------------
- [ ] The following were changed in a non-backward compatible way and requires a major version bump:
  - *[link to the breaking change in the diff]*
- [ ] Something public was added or changed in backward compatible way, this requires a minor version bump
- [x] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch release

How to QA
-------
- [ ] run unit-tests
- [ ] run integration tests
- [ ] run the following related examples: main example, with [this patch](https://jira.atl.workiva.net/secure/attachment/470370/wp-3756_testing.patch).



**Required:**
@dustinlessard-wf @evanweible-wf @maxwellpeterson-wf 
@trentgrover-wf @sebastianmalysa-wf

**FYI:**
@jayudey-wf 
