### PR TITLE
WP-1030 Release state_machine 2.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: state_machine
-version: 2.0.0
+version: 2.0.1
 description: Finite state machine library. Easily define legal state transitions. Listen to state entrances, departures, and transitions.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [WP-3658 : added docs.yml](https://github.com/Workiva/state_machine/pull/33)
* [Wp 3756 : state_machine is now disposable](https://github.com/Workiva/state_machine/pull/34)
* [CP-1224 cleanup old scripts, state_machine](https://github.com/Workiva/state_machine/pull/29)
* [CP-2624 The codecov badge was no longer working](https://github.com/Workiva/state_machine/pull/30)
* [CP-2945 Adding smithy.yaml](https://github.com/Workiva/state_machine/pull/31)


Requested by: @dustinlessard-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/state_machine/compare/2.0.0...version-bump-state_machine-2-0-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/state_machine/compare/2.0.0...2.0.1