### PR TITLE
WP-6394 Fix constructor usages in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import 'package:state_machine/state_machine.dart';
 Once created, the `StateMachine` will be used to create states and state transitions.
 
 ```dart
-StateMachine light = new StateMachine();
+StateMachine light = new StateMachine('light');
 ```
 
 ### Define a Set of States
@@ -121,7 +121,7 @@ turnOn(); // "Left: off"
 The `State` class exposes a static instance `State.any` that can be used as a wildcard when defining a state transition.
 
 ```dart
-StateMachine machine = new StateMachine();
+StateMachine machine = new StateMachine('machine');
 State isFailed = machine.newState('failed');
 
 // This transition will be valid regardless of which state the machine is in.
@@ -134,7 +134,7 @@ states in order to execute the transition. If that's not the case, an `IllegalSt
 
 ```dart
 // Consider a door with the following states and transitions.
-StateMachine door = new StateMachine();
+StateMachine door = new StateMachine('door');
 
 State isOpen = door.newState('open');
 State isClosed = door.newState('closed');
@@ -164,12 +164,12 @@ To handle this, state transitions support cancellation conditions.
 // Consider two state machines - a person and a door.
 // The door can be locked or unlocked and the person
 // can be with or without a key.
-StateMachine door = new StateMachine();
+StateMachine door = new StateMachine('door');
 State isLocked = door.newState('locked');
 State isUnlocked = door.newState('unlocked');
 StateTransition unlock = door.newStateTransition('unlock', [isLocked], isUnlocked);
 
-StateMachine person = new StateMachine();
+StateMachine person = new StateMachine('person');
 State isWithKey = person.newState('withKey');
 State isWithoutKey = person.newState('withoutKey');
 StateTransition obtainKey = person.newStateTransition('obtainKey', [isWithoutKey], isWithKey);

--- a/lib/src/state_machine.dart
+++ b/lib/src/state_machine.dart
@@ -24,7 +24,7 @@ import 'package:w_common/disposable.dart';
 ///
 /// States must be created from a [StateMachine] instance:
 ///
-///     StateMachine door = new StateMachine();
+///     StateMachine door = new StateMachine('door');
 ///
 ///     State isOpen = door.newState('open');
 ///     State isClosed = door.newState('closed');
@@ -184,7 +184,7 @@ class StateChange {
 /// To demonstrate:
 ///
 ///     // 1.
-///     StateMachine machine = new StateMachine();
+///     StateMachine machine = new StateMachine('switch');
 ///
 ///     // 2.
 ///     State isOn = machine.newState('on');
@@ -315,7 +315,7 @@ class StateMachine extends Disposable {
 /// state. The machine must be in one of the "from" states in order
 /// for this transition to occur.
 ///
-///     StateMachine door = new StateMachine();
+///     StateMachine door = new StateMachine('door');
 ///
 ///     State isOpen = door.newState('open');
 ///     State isClosed = door.newState('closed');
@@ -353,13 +353,13 @@ class StateMachine extends Disposable {
 /// the following example that integrates two separate state machines
 /// to represent the state of a lamp.
 ///
-///     StateMachine powerCord = new StateMachine();
+///     StateMachine powerCord = new StateMachine('powerCord');
 ///     State isPluggedIn = powerCord.newState('pluggedIn');
 ///     State isUnplugged = powerCord.newState('unplugged');
 ///     StateTransition plugIn = powerCord.newStateTransition('plugIn', [isUnplugged], isPluggedIn);
 ///     StateTransition unplug = powerCord.newStateTransition('unplug', [isPluggedIn], isUnplugged);
 ///
-///     StateMachine lamp = new StateMachine();
+///     StateMachine lamp = new StateMachine('lamp');
 ///     State isOn = lamp.newState('on');
 ///     State isOff = lamp.newState('off');
 ///     StateTransition turnOn = lamp.newStateTransition('turnOn', [isOff], isOn);

--- a/lib/state_machine.dart
+++ b/lib/state_machine.dart
@@ -24,7 +24,7 @@
 ///
 /// Simple usage:
 ///
-///     StateMachine door = new StateMachine();
+///     StateMachine door = new StateMachine('door');
 ///     State isOpen = door.newState('open');
 ///     State isClosed = door.newState('closed');
 ///     StateTransition open = door.newStateTransition('open', [isClosed], isOpen);
@@ -46,7 +46,7 @@
 ///       StateMachine _machine;
 ///
 ///       Door() {
-///         _machine = new StateMachine();
+///         _machine = new StateMachine('door');
 ///         isOpen = _machine.newState('open');
 ///         isClosed = _machine.newState('closed');
 ///         open = _machine.newStateTransition('open', [isClosed], isOpen);


### PR DESCRIPTION
## Description

Fixes #40 

There were several examples of constructing a `StateMachine` in our documentation and examples that were missing a required parameter.

## Code Review

@Workiva/app-frameworks 