### PR TITLE
Migration: Update Dockerfile to mirror smithy.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,42 @@
 language: dart
+sudo: required
+
 dart:
   - stable
+
+addons:
+  apt:
+    packages:
+    - ttf-kochi-mincho
+    - ttf-kochi-gothic
+    - ttf-dejavu
+    - ttf-indic-fonts
+    - fonts-tlwg-garuda
+
+before_install:
+  # Workaround for https://github.com/travis-ci/travis-ci/issues/8607
+  - sudo rm -vf /etc/apt/sources.list.d/*riak*
+  # Content shell needs this font. Since it has a EULA, we need to manually
+  # install it.
+  #
+  # TODO: remove this and use "sudo: false" when travis-ci/travis-ci#4714 is
+  # fixed.
+  - sudo apt-get update -yq
+  - sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
+  - sudo apt-get install msttcorefonts -qq
+
+  - mkdir -p bin
+  - export PATH="$PATH:`pwd`/bin/"
+  - ln -s `which chromium-browser` bin/google-chrome
+
+  - wget "http://gsdview.appspot.com/dart-archive/channels/stable/release/latest/dartium/content_shell-linux-x64-release.zip"
+  - unzip content_shell-linux-x64-release.zip
+  - ln -s `pwd`/`echo drt-linux-*`/content_shell bin/content_shell
+
+  -  export DISPLAY=:99.0
+  -  export PATH=$PATH":$PWD"
+  -  sh -e /etc/init.d/xvfb start
+
 script:
   - pub get --packages-dir
   - pub run dart_dev analyze

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:350667 as build
+
+# Build Environment Vars
+ARG BUILD_ID
+ARG BUILD_NUMBER
+ARG BUILD_URL
+ARG GIT_COMMIT
+ARG GIT_BRANCH
+ARG GIT_TAG
+ARG GIT_COMMIT_RANGE
+ARG GIT_HEAD_URL
+ARG GIT_MERGE_HEAD
+ARG GIT_MERGE_BRANCH
+ARG GIT_SSH_KEY
+ARG KNOWN_HOSTS_CONTENT
+WORKDIR /build/
+ADD . /build/
+
+RUN mkdir /root/.ssh && \
+    echo "$KNOWN_HOSTS_CONTENT" > "/root/.ssh/known_hosts" && \
+    chmod 700 /root/.ssh/ && \
+    umask 0077 && echo "$GIT_SSH_KEY" >/root/.ssh/id_rsa && \
+    eval "$(ssh-agent -s)" && ssh-add /root/.ssh/id_rsa
+RUN echo "Starting the before_script section" && \
+		dart --version && \
+		echo "before_script section completed"
+RUN echo "Starting the script section" && \
+		pub get && \
+		echo "script section completed"
+ARG BUILD_ARTIFACTS_DART-DEPENDENCIES=/build/pubspec.lock
+FROM scratch


### PR DESCRIPTION

## Overview
In order to improve build isolation, reduce costs, reduce support burden, remove black magic, and improve local consistency, we are migrating away from smithy.yaml and existing Smithy infrastructure to Dockerfile builds supported by off the shelf AWS resources.

Reviewing and merging this PR is the first step in that process; this PR simply copies the contents of your smithy.yaml into a more explicit Dockerfile. 
In order to begin running Dockerfile builds you will need to enable Dockerfile builds from your [repo configuration page in Smithy](https://ci.webfilings.com/Workiva/state_machine).
Once you have enabled Dockerfile builds for your repo, rebuilding the PR build in smithy will trigger the newly enabled Dockefile build.

### Expectations
With only a [couple of exceptions](https://dev.workiva.net/docs/internal-software/workiva-build/migration-from-smithy#differences-in-behavior-between-workiva-build-and-smithy-builds) the behavior of this new Dockerfile should match the existing behavior in your smithy.yaml
Therefore, our expectations are for you to merge this PR as soon as possible. If for any reason you discover a problem post merge, you can disable the new builds and re-enable smithy.yaml builds in your [repo configuration page in Smithy](https://ci.webfilings.com/Workiva/state_machine)

### Support/Questions
The migration to Dockerfile builds is our top priority, so please reach out to us if you have any questions, comments, or concerns during this process. Non-urgent questions should go into [Confluence Questions](https://wiki.atl.workiva.net/questions) and urgent support can be requested in the Support: Build Tools Hipchat Room 

### More Info
Information about the migration to dockerfile can be found [here](https://dev.workiva.net/docs/internal-software/workiva-build/migration-from-smithy#differences-in-behavior-between-workiva-build-and-smithy-builds)
A user guide for Dockerfile builds can be found [here](https://dev.workiva.net/docs/internal-software/workiva-build/user-guide)


@dustinlessard-wf

Link to Dockerfile build: https://ci.webfilings.com/build/1376262