### PR TITLE
AF-2818 dart 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,12 @@
 language: dart
 sudo: required
-
 dart:
   - 1.24.3
-
+  - stable
 addons:
-  apt:
-    packages:
-    - ttf-kochi-mincho
-    - ttf-kochi-gothic
-    - ttf-dejavu
-    - ttf-indic-fonts
-    - fonts-tlwg-garuda
-
-before_install:
-  # Workaround for https://github.com/travis-ci/travis-ci/issues/8607
-  - sudo rm -vf /etc/apt/sources.list.d/*riak*
-  # Content shell needs this font. Since it has a EULA, we need to manually
-  # install it.
-  #
-  # TODO: remove this and use "sudo: false" when travis-ci/travis-ci#4714 is
-  # fixed.
-  - sudo apt-get update -yq
-  - sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
-  - sudo apt-get install msttcorefonts -qq
-
-  - mkdir -p bin
-  - export PATH="$PATH:`pwd`/bin/"
-  - ln -s `which chromium-browser` bin/google-chrome
-
-  - wget "http://gsdview.appspot.com/dart-archive/channels/stable/release/latest/dartium/content_shell-linux-x64-release.zip"
-  - unzip content_shell-linux-x64-release.zip
-  - ln -s `pwd`/`echo drt-linux-*`/content_shell bin/content_shell
-
-  -  export DISPLAY=:99.0
-  -  export PATH=$PATH":$PWD"
-  -  sh -e /etc/init.d/xvfb start
-
+  chrome: stable
 script:
-  - pub get --packages-dir
+  - pub get
   - pub run dart_dev analyze
   - pub run dart_dev format --check
   - pub run dart_dev test
-  - pub run dart_dev coverage --no-html
-  - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/example/index.html
+++ b/example/index.html
@@ -19,8 +19,8 @@ limitations under the License.-->
     <title>State Machine Example: Door</title>
 
     <link rel="stylesheet" href="door.css">
-    <script type="application/dart" src="door_example.dart"></script>
-    <script src="packages/browser/dart.js"></script>
+    <script defer src="door_example.dart.js"></script>
+    
 </head>
 <body>
     <div id="container">

--- a/lib/src/state_machine.dart
+++ b/lib/src/state_machine.dart
@@ -404,11 +404,11 @@ class StateTransition extends Disposable implements Function {
   /// Stream of transition events from [_streamController] as
   /// a broadcast stream. Transition event occurs every time
   /// this transition executes successfully.
-  Stream _stream;
+  Stream<StateChange> _stream;
 
   /// Stream controller used internally to create a stream of
   /// transition events.
-  StreamController _streamController;
+  StreamController<StateChange> _streamController;
 
   /// [State] to transition the machine to when executing
   /// this transition.
@@ -419,7 +419,7 @@ class StateTransition extends Disposable implements Function {
     if (_to == State.any)
       throw new ArgumentError(
           'Cannot transition to the wildcard state "State.any"');
-    _streamController = new StreamController();
+    _streamController = new StreamController<StateChange>();
     manageStreamController(_streamController);
     _stream = _streamController.stream.asBroadcastStream();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,19 +8,17 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/state_machine
 
-dependencies:
-  w_common: ^1.2.0
-dev_dependencies:
-  browser: "^0.10.0"
-  coverage: "^0.7.3"
-  dart_dev: "^1.0.0"
-  dart_style: "^0.2.0"
-  dartdoc: "^0.8.0"
-  test: "^0.12.3+2"
 environment:
-  sdk: ">=1.24.2 <2.0.0"
-transformers:
-- $dart2js:
-    sourceMaps: true
-    csp: true
-    minify: true
+  sdk: '>=1.24.3<3.0.0'
+
+dependencies:
+  w_common: ^1.15.0
+
+dev_dependencies:
+  build_runner: ">=0.6.0 <1.0.0"
+  build_test: ">=0.9.0 <1.0.0"
+  build_web_compilers: ">=0.2.0 <1.0.0"
+  coverage: ">=0.10.0 <0.13.0"
+  dart_dev: ">=1.9.6 <3.0.0"
+  dart_style: ^1.0.0
+  test: ">=0.12.30 <2.0.0"


### PR DESCRIPTION
# Problem
This library was not installable under dart 2

# Solution
- Update dependency ranges to allow use under Dart 1 and Dart 2
- Specify a generic stream and stream controller type
- Clean up travis CI config and run under dart 1&2

# Testing
 - [ ] CI passes under dart 1 & 2