### PR TITLE
AF-2820 Release state_machine 2.0.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: state_machine
-version: 2.0.3
+version: 2.0.4
 description: Finite state machine library. Easily define legal state transitions. Listen to state entrances, departures, and transitions.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>
@@ -19,6 +19,6 @@ dev_dependencies:
   build_test: ">=0.9.0 <1.0.0"
   build_web_compilers: ">=0.2.0 <1.0.0"
   coverage: ">=0.10.0 <0.13.0"
-  dart_dev: ">=1.9.6 <3.0.0"
+  dart_dev: ^2.0.0
   dart_style: ^1.0.0
   test: ">=0.12.30 <2.0.0"


### PR DESCRIPTION
Consume the stable 2.0.0 release of dart_dev.

@Workiva/app-frameworks