### PR TITLE
CPLAT-6849: Add disposable type name(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Don’t commit the following directories created by pub.
 build/
 packages/
-packages
+.packages
 .buildlog
 .pub/
 pubspec.lock
@@ -22,3 +22,6 @@ dartdoc-viewer
 
 #don't commit screenshots from functional tests
 screenshots/
+
+#dont't commit files created by build
+.dart_tool/

--- a/example/door.dart
+++ b/example/door.dart
@@ -18,6 +18,9 @@ import 'package:state_machine/state_machine.dart';
 import 'package:w_common/disposable.dart';
 
 class Door extends Disposable {
+  @override
+  String get disposableTypeName => 'Door';
+
   Door() {
     _machine = new StateMachine('door');
     manageDisposable(_machine);

--- a/lib/src/state_machine.dart
+++ b/lib/src/state_machine.dart
@@ -67,6 +67,9 @@ import 'package:w_common/disposable.dart';
 /// 2. It reads better when calling the state to determine if it's active,
 /// as demonstrated above when calling `isOpen()` and `isClosed()`.
 class State extends Disposable implements Function {
+  @override
+  String get disposableTypeName => 'State';
+
   /// Wildcard state that should be used to define state transitions
   /// that allow transitioning from any state.
   static State any = new State._wildcard();
@@ -209,6 +212,9 @@ class StateChange {
 /// states and the state transitions. See [State] and
 /// [StateTransition] for more information.
 class StateMachine extends Disposable {
+  @override
+  String get disposableTypeName => 'StateMachine';
+
   /// Name of the state machine. Used for debugging.
   String name;
 
@@ -387,6 +393,9 @@ class StateMachine extends Disposable {
 ///     turnOn(); // "Light is on!"
 ///     unplug(); // "Light is off :("
 class StateTransition extends Disposable implements Function {
+  @override
+  String get disposableTypeName => 'StateTransition';
+
   /// Name of the state transition. Used for debugging.
   String name;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,15 +9,15 @@ authors:
 homepage: https://github.com/Workiva/state_machine
 
 environment:
-  sdk: '>=1.24.3<3.0.0'
+  sdk: '>=1.24.3 <3.0.0'
 
 dependencies:
   w_common: ^1.15.0
 
 dev_dependencies:
-  build_runner: ">=0.6.0 <1.0.0"
-  build_test: ">=0.9.0 <1.0.0"
-  build_web_compilers: ">=0.2.0 <1.0.0"
+  build_runner: ">=0.6.0 <2.0.0"
+  build_test: ">=0.9.0 <2.0.0"
+  build_web_compilers: ">=0.2.0 <3.0.0"
   coverage: ">=0.10.0 <0.13.0"
   dart_dev: ^2.0.0
   dart_style: ^1.0.0


### PR DESCRIPTION
Some of the classes that extend or mixin `Disposable` missing `disposableTypeName` override.
     This PR will add missing overrides, where it's necessary