### PR TITLE
Expose transition stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ screenshots/
 
 #dont't commit files created by build
 .dart_tool/
+
+.idea/

--- a/lib/src/state_machine.dart
+++ b/lib/src/state_machine.dart
@@ -415,6 +415,10 @@ class StateTransition extends Disposable implements Function {
   /// this transition executes successfully.
   Stream<StateChange> _stream;
 
+  /// Stream of transition events. A transition event occurs every time this
+  /// transition executes successfully.
+  Stream<StateChange> get stream => _stream;
+
   /// Stream controller used internally to create a stream of
   /// transition events.
   StreamController<StateChange> _streamController;
@@ -437,6 +441,7 @@ class StateTransition extends Disposable implements Function {
   /// this transition executes successfully.
   ///
   /// [onData] will be called with the [State] that was transitioned from.
+  @Deprecated('Listen to \'stream\' directly')
   StreamSubscription listen(void onTransition(StateChange stateChange),
       {Function onError, void onDone(), bool cancelOnError}) {
     final streamSubscription = listenToStream(_stream, onTransition,

--- a/test/state_transition_test.dart
+++ b/test/state_transition_test.dart
@@ -93,7 +93,7 @@ void main() {
         () async {
       var c = Completer();
       var fromStates = [];
-      breakThrough.listen((StateChange stateChange) {
+      breakThrough.stream.listen((StateChange stateChange) {
         fromStates.add(stateChange.from);
         if (fromStates.length >= 2) {
           c.complete();


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Consumers don't have access to the full functionality of the transition stream.

## Changes
  <!-- What this PR changes to fix the problem. -->
Instead of passing through `listen()`, give consumers direct access to the transition stream.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
Make state transition stream available to consumers

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/state_machine/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/state_machine/blob/master/CONTRIBUTING.md#manual-testing-criteria
