### PR TITLE
Expose StateTransition canCall method

### DIFF
--- a/lib/src/state_machine.dart
+++ b/lib/src/state_machine.dart
@@ -449,6 +449,32 @@ class StateTransition extends Disposable implements Function {
     return streamSubscription;
   }
 
+  /// Execute all the pre-checks to understand
+  /// if a transition can take place or not.
+  /// Will call any tests registered via [cancelIf],
+  /// canceling the transition if any test
+  /// returns true.
+  ///
+  /// Returns true if transition can be executed,
+  /// false if it's not possible.
+  bool canCall([payload]) {
+    StateChange stateChange = StateChange._(_machine.current, _to, payload);
+
+    // Verify the transition is valid from the current state.
+    if (!_from.contains(stateChange.from) && !_from.contains(State.any)) {
+      return false;
+    }
+
+    // Allow transition to be canceled.
+    for (int i = 0; i < _cancelTests.length; i++) {
+      if (_cancelTests[i](stateChange)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   /// Execute this transition. Will call any tests registered
   /// via [cancelIf], canceling the transition if any test
   /// returns true. Otherwise, the transition will occur

--- a/test/state_test.dart
+++ b/test/state_test.dart
@@ -83,5 +83,16 @@ void main() {
       expect(s, contains('machine has yet to start'));
       expect(s, isNot(contains('__none__')));
     });
+
+    test('canCall should return accordingly', () async {
+      var c = Completer();
+      isOff.onLeave.listen(c.complete);
+      machine.start(isOff);
+      expect(turnOn.canCall(), isTrue);
+      turnOn();
+      expect(isOn(), isTrue);
+      expect((await c.future).to, equals(isOn));
+      expect(turnOn.canCall(), isFalse);
+    });
   });
 }


### PR DESCRIPTION
## Motivation

Similar #57 but for a different task.

What I'm trying to achieve is to have a test function that allows me to check whenever a transition is feasible in an arbitrary state.

Imagine if you're trying to model light on/off switch.
your UI needs a method to check whenever the on or off action is available to eventually disable the related button.

## Changes

I just exposed the StateTransition.call pre-checks into a separate method named `canCall` which would allow achieving the above.

I also thought about merging this code with the same checks in the `call` method but I didn't want to conflict with #57 

#### Release Notes

Exported the StateTransition `canCall` method

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist

- [x] Tests were updated and provide good coverage of the changeset and other affected code
- [x] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/state_machine/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/state_machine/blob/master/CONTRIBUTING.md#manual-testing-criteria
