### PR TITLE
chore(state) expose __none__ state

### DIFF
--- a/test/state_machine_test.dart
+++ b/test/state_machine_test.dart
@@ -32,6 +32,7 @@ void main() {
 
     test('should be in a dummy state until the machine has been started', () {
       expect(machine.current.name, equals('__none__'));
+      expect(machine.current.isNone, isTrue);
     });
 
     test('should throw if machine is started more than once', () {

--- a/test/state_test.dart
+++ b/test/state_test.dart
@@ -79,6 +79,7 @@ void main() {
 
     test('.toString() should explain what the __none__ state means', () {
       State noneState = machine.current;
+      expect(noneState.isNone, isTrue);
       String s = noneState.toString();
       expect(s, contains('machine has yet to start'));
       expect(s, isNot(contains('__none__')));


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

I'm listening to a state `onEnter` event to perform some database changes when a transition happens.

I noticed that this event was triggered also just after the `stm.start(initialState);` line.

To cope with this event and ignore this first initial transition I checked the source code and found that this event has a stub `__none__` state.

So in my code I ended up with this:

```
state.onEnter((change) {
  if (change.from.name != '__none__') {
    // do something
  }
});
```

I think this is not the best approach as I'm relying on some internal representation.
That's why I'm exposing this `State.isNone` getter.

## Changes
  <!-- What this PR changes to fix the problem. -->

- `State.isNone` getter added
- `StateChange.isInitial`



#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

Exposed `State.isNone` and `StateChange.isInitial` to distinguish initial state change events.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [x] Tests were updated and provide good coverage of the changeset and other affected code
- [x] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/state_machine/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/state_machine/blob/master/CONTRIBUTING.md#manual-testing-criteria
