### PR TITLE
Dart 2.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:2
 
 WORKDIR /build/
 ADD pubspec.yaml /build


### PR DESCRIPTION
Summary
---
This batch updates CI to use Dart 2.19. In most cases, updating Just Works™, 
but here's some things that have changed or may cause problems while updating.
- The pub and dart2js aliases have been removed. You may need to replace bare pub commands. See the replacements here https://wiki.atl.workiva.net/display/CP/Dart+2.18+FAQ
- There may be some new lints, or lints that actually function better and now find new issues that need fixing or ignoring.
- Some lints may have been raised to warnings that now need fixing or ignoring until fixed.
- Dockerfiles or skynet may try to install things that don't work quite right on newer debian 11 (bullseye)
  - Potential examples are installing python or nodejs into the dart images
- If you have build.yaml files that "split" the builders into separate targets, you may have to exclude a new builder
```
  build_resolvers|transitive_digests:
    enabled: false
```

These PRs are ok to get reviewed and approved. 
If it is out of draft and there isn't a `Hold`` label, then it is ok to merge.

For support go to `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/dart_219`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_219)