### PR TITLE
Raise the build_web_compilers dependency max to v5.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,6 @@ dependencies:
 
 dev_dependencies:
     build_runner: ^2.0.0
-    build_web_compilers: ^3.0.0
+    build_web_compilers: '>=3.0.0 <5.0.0'
     dart_style: ^2.1.1
     test: ^1.17.12


### PR DESCRIPTION
This PR raises the max version of build_web_compilers to 5.0.0 to prep for Dart 3. 
Since we're all on Dart 2.19 right now, no pub resolution will change as we can't
actually resolve to build_web_compilers 4+ without Dart 3.

Passing CI should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `$support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/build_web_compilers_raise_max_v5_0_0`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/build_web_compilers_raise_max_v5_0_0)