### PR TITLE
RM-199680 Release state_machine 3.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: state_machine
-version: 3.0.0
+version: 3.0.1
 description: Finite state machine library. Easily define legal state transitions.
     Listen to state entrances, departures, and transitions.
 homepage: https://github.com/Workiva/state_machine


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Update dev dependencies for analyzer 2](https://github.com/Workiva/state_machine/pull/85)
	* [Dart 2.19](https://github.com/Workiva/state_machine/pull/89)
	* [DSC-10120 - Complete transition to GHA](https://github.com/Workiva/state_machine/pull/90)
	* [FEDX-1710: Workiva Analysis Options v2](https://github.com/Workiva/state_machine/pull/93)
	* [Raise the build_web_compilers dependency max to v5.0.0](https://github.com/Workiva/state_machine/pull/94)
	* [raise_min_dart_sdk_2_19](https://github.com/Workiva/state_machine/pull/95)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/state_machine/compare/3.0.0...Workiva:release_state_machine_3.0.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/state_machine/compare/3.0.0...3.0.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4641974571237376/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4641974571237376/?repo_name=Workiva%2Fstate_machine&pull_number=96)