### PR TITLE
RM-302022 Release state_machine 3.0.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: state_machine
-version: 3.0.1
+version: 3.0.2
 description: Finite state machine library. Easily define legal state transitions.
     Listen to state entrances, departures, and transitions.
 homepage: https://github.com/Workiva/state_machine


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [2_raise_build_deps_max_for_analyzer_10](https://github.com/Workiva/state_machine/pull/99)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/state_machine/compare/3.0.1...Workiva:release_state_machine_3.0.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/state_machine/compare/3.0.1...3.0.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4641974571237376/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4641974571237376/?repo_name=Workiva%2Fstate_machine&pull_number=100)